### PR TITLE
[Fix] Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2024 LINE Corporation
+Copyright 2024 LY Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2017 LINE Corporation. All rights reserved.
-  ~ LINE Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+  ~ Copyright (c) 2017 LY Corporation. All rights reserved.
+  ~ LY Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
   -->
 
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2018 LINE Corporation. All rights reserved.
-  ~ LINE Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+  ~ Copyright (c) 2018 LY Corporation. All rights reserved.
+  ~ LY Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
   -->
 
 <!DOCTYPE suppressions PUBLIC

--- a/examples/javaflagr-abtest-example/src/main/java/com/linecorp/flagship4j/examples/JavaFlagrAbTestExample.java
+++ b/examples/javaflagr-abtest-example/src/main/java/com/linecorp/flagship4j/examples/JavaFlagrAbTestExample.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/javaflagr-example/src/main/java/com/linecorp/flagship4j/examples/JavaFlagrExample.java
+++ b/examples/javaflagr-example/src/main/java/com/linecorp/flagship4j/examples/JavaFlagrExample.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/javaflagr-spring-boot-web-example/src/main/java/com/linecorp/flagship4j/examples/JavaflagrSpringBootWebExampleApplication.java
+++ b/examples/javaflagr-spring-boot-web-example/src/main/java/com/linecorp/flagship4j/examples/JavaflagrSpringBootWebExampleApplication.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/javaflagr-spring-boot-web-example/src/main/java/com/linecorp/flagship4j/examples/controllers/HelloWorldController.java
+++ b/examples/javaflagr-spring-boot-web-example/src/main/java/com/linecorp/flagship4j/examples/controllers/HelloWorldController.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/javaflagr-spring-boot-web-example/src/main/resources/application.yml
+++ b/examples/javaflagr-spring-boot-web-example/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 #
-# Copyright 2024 LINE Corporation
+# Copyright 2024 LY Corporation
 #
-# LINE Corporation licenses this file to you under the Apache License,
+# LY Corporation licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at:
 #

--- a/examples/openfeature-abtest-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureAbTestExample.java
+++ b/examples/openfeature-abtest-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureAbTestExample.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/openfeature-canary-release-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureCanaryExample.java
+++ b/examples/openfeature-canary-release-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureCanaryExample.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/openfeature-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureExample.java
+++ b/examples/openfeature-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureExample.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/openfeature-spring-boot-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureSpringBootExampleApplication.java
+++ b/examples/openfeature-spring-boot-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureSpringBootExampleApplication.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/examples/openfeature-spring-boot-example/src/main/resources/application.yaml
+++ b/examples/openfeature-spring-boot-example/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 #
-# Copyright 2024 LINE Corporation
+# Copyright 2024 LY Corporation
 #
-# LINE Corporation licenses this file to you under the Apache License,
+# LY Corporation licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at:
 #

--- a/examples/openfeature-white-list-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureWhiteListExample.java
+++ b/examples/openfeature-white-list-example/src/main/java/com/linecorp/flagship4j/examples/OpenFeatureWhiteListExample.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/DefaultOpenFlagr.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/DefaultOpenFlagr.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/OpenFlagr.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/OpenFlagr.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/clients/DefaultOpenFlagrApiClient.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/clients/DefaultOpenFlagrApiClient.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/clients/EvaluationApi.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/clients/EvaluationApi.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/clients/OpenFlagrApiClient.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/clients/OpenFlagrApiClient.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/configs/OpenFlagrConfig.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/configs/OpenFlagrConfig.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/enums/EffectiveVariant.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/enums/EffectiveVariant.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/enums/EvaluationContextFlagTagsOperator.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/enums/EvaluationContextFlagTagsOperator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/IllegalEnumValueException.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/IllegalEnumValueException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/OpenFlagrException.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/OpenFlagrException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/OpenFlagrNoFlagKeyException.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/OpenFlagrNoFlagKeyException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/OpenFlagrNoVariantException.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/exceptions/OpenFlagrNoVariantException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/EvaluationContext.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/EvaluationContext.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/EvaluationDebugLog.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/EvaluationDebugLog.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/EvaluationResult.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/EvaluationResult.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/SegmentDebugLog.java
+++ b/libs/flagship4j-javaflagr-core/src/main/java/com/linecorp/flagship4j/javaflagr/models/SegmentDebugLog.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-openfeature-provider-javaflagr/src/main/java/com/linecorp/flagship4j/openfeature/OpenFlagrProvider.java
+++ b/libs/flagship4j-openfeature-provider-javaflagr/src/main/java/com/linecorp/flagship4j/openfeature/OpenFlagrProvider.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/libs/flagship4j-openfeature-provider-javaflagr/src/main/java/com/linecorp/flagship4j/openfeature/extensions/EvaluationContextExtensionMethods.java
+++ b/libs/flagship4j-openfeature-provider-javaflagr/src/main/java/com/linecorp/flagship4j/openfeature/extensions/EvaluationContextExtensionMethods.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/settings/license_template/LICENSE
+++ b/settings/license_template/LICENSE
@@ -1,6 +1,6 @@
-Copyright ${license.git.copyrightLastYear} LINE Corporation
+Copyright ${license.git.copyrightLastYear} LY Corporation
 
-LINE Corporation licenses this file to you under the Apache License,
+LY Corporation licenses this file to you under the Apache License,
 version 2.0 (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at:
 

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/annotations/ControllerFeatureToggle.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/annotations/ControllerFeatureToggle.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/annotations/VariantKey.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/annotations/VariantKey.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/aspect/ControllerFeatureToggleAspect.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/aspect/ControllerFeatureToggleAspect.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/bean/BeanLocator.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/bean/BeanLocator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/client/FlagrEvalClient.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/client/FlagrEvalClient.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/client/impl/FlagrEvalClientImpl.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/client/impl/FlagrEvalClientImpl.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/client/stub/FlagrEvalClientStub.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/client/stub/FlagrEvalClientStub.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/config/FlagrEvalClientConfiguration.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/config/FlagrEvalClientConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/config/FlagrExceptionHandler.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/config/FlagrExceptionHandler.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/config/properties/Flagship4jToggleFlagrProperties.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/config/properties/Flagship4jToggleFlagrProperties.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/ErrorResponseException.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/ErrorResponseException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrApiNotFoundException.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrApiNotFoundException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrErrorResponse.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrErrorResponse.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrException.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrResponseStatusException.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/FlagrResponseStatusException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/IllegalEnumValueException.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/exception/IllegalEnumValueException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/Context.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/Context.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/ContextHolder.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/ContextHolder.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/EvaluationContext.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/EvaluationContext.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/EvaluationDebugLog.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/EvaluationDebugLog.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/FlagrEvalClientSettings.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/FlagrEvalClientSettings.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/PostEvaluationResponse.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/PostEvaluationResponse.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/SegmentDebugLog.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/SegmentDebugLog.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/enums/EffectiveVariant.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/enums/EffectiveVariant.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/enums/HttpResponseStatus.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/model/enums/HttpResponseStatus.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/service/FlagrEvalService.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/service/FlagrEvalService.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/service/impl/FlagrEvalServiceImpl.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/service/impl/FlagrEvalServiceImpl.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/utils/RandomUtils.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/utils/RandomUtils.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/utils/SecureRandomUtils.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/main/java/com/linecorp/flagship4j/javaflagr/utils/SecureRandomUtils.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/TestFlagrDataGenerator.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/TestFlagrDataGenerator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/annotation/TestService.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/annotation/TestService.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/annotation/TestWebClient.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/annotation/TestWebClient.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/aspect/ControllerFeatureToggleAspectTest.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/aspect/ControllerFeatureToggleAspectTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/aspect/FlagrAnnotationTest.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/aspect/FlagrAnnotationTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/base/RestApiClientTestBase.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/base/RestApiClientTestBase.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/client/FlagrEvalClientTest.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/client/FlagrEvalClientTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/AbstractTestContextConfiguration.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/AbstractTestContextConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/DefaultTestContextConfiguration.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/DefaultTestContextConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/FlagrExceptionHandlerTest.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/FlagrExceptionHandlerTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/TestContextConfiguration.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/config/TestContextConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/fixture/PostEvaluationResponseFixture.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/fixture/PostEvaluationResponseFixture.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/fixture/TestContextFixture.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/fixture/TestContextFixture.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/serivce/FlagrEvalServiceTest.java
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/java/com/linecorp/flagship4j/javaflagr/serivce/FlagrEvalServiceTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/resources/application.yaml
+++ b/supports/flagship4j-javaflagr-spring-boot-web-starter/src/test/resources/application.yaml
@@ -1,7 +1,7 @@
 #
-# Copyright 2024 LINE Corporation
+# Copyright 2024 LY Corporation
 #
-# LINE Corporation licenses this file to you under the Apache License,
+# LY Corporation licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at:
 #

--- a/supports/flagship4j-openfeature-spring-boot-starter/src/main/java/com/linecorp/flagship4j/openfeature/springframework/boot/autoconfigure/OpenFeatureAutoConfiguration.java
+++ b/supports/flagship4j-openfeature-spring-boot-starter/src/main/java/com/linecorp/flagship4j/openfeature/springframework/boot/autoconfigure/OpenFeatureAutoConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/supports/flagship4j-openfeature-spring-boot-starter/src/main/java/com/linecorp/flagship4j/openfeature/springframework/boot/autoconfigure/OpenFeatureProperties.java
+++ b/supports/flagship4j-openfeature-spring-boot-starter/src/main/java/com/linecorp/flagship4j/openfeature/springframework/boot/autoconfigure/OpenFeatureProperties.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2024 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *


### PR DESCRIPTION
## Descriptions

Fix license typo

## Changes

- Update license copyright text from 2021 to 2024
- Change `LINE Corporation` to `LY Corporation`