### PR TITLE
Update versioning and publishing configuration

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Publish package
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=1 --info publish closeAndReleaseStagingRepository
+          ./gradlew --no-daemon --stacktrace --max-workers=1 --info publish closeAndReleaseStagingRepositories
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'com.linecorp.gradle.license-git' version '0.1.0'
 }
 
+version = System.getenv("SDK_VERSION") ?: (
+        "0.1.40" + (project.hasProperty("release") ? "" : "-SNAPSHOT")
+)
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'idea'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 group = com.linecorp.flagship4j
-version = 0.1.40-SNAPSHOT
 
 springbootVersion = 2.7.14
 springDependencyVersion = 1.0.15.RELEASE


### PR DESCRIPTION
- make version can be assigned from env
- change the publish command due to the fail in [Action](https://github.com/line/Flagship4j/actions/runs/14750585624/job/41406929859)
```
FAILURE: Build failed with an exception.

* What went wrong:
Task 'closeAndReleaseStagingRepository' not found in root project 'flagship4j'. Some candidates are: 'closeAndReleaseStagingRepositories'.

* Try:
> Run gradlew tasks to get a list of available tasks.
> Run with --debug option to get more log output.
> Run with --scan to get full insights.
```